### PR TITLE
added textarea value and defaultValue

### DIFF
--- a/src/tink/domspec/Attributes.hx
+++ b/src/tink/domspec/Attributes.hx
@@ -73,6 +73,8 @@ typedef TextAreaAttr = {>GlobalAttr,
   @:optional var readonly(default, never):Bool;
   @:optional var required(default, never):Bool;
   @:optional var rows(default, never):Int;
+  @:optional var value(default, never):String;
+  @:optional var defaultValue(default, never):String;
   @:optional var wrap(default, never):String;
 }
 


### PR DESCRIPTION
react have a warning if you use children for the content instead of value and/or defaultValue