### PR TITLE
Proposing integrating "role" global attribute.

### DIFF
--- a/src/tink/domspec/Attributes.hx
+++ b/src/tink/domspec/Attributes.hx
@@ -16,6 +16,7 @@ typedef GlobalAttr<Style> = {
   @:optional var draggable(default, never):Bool;
   @:optional var spellcheck(default, never):Bool;
   @:optional var style(default, never):Style;
+  @:optional var role(def, never):String;
 }
 
 typedef DetailsAttr = {>GlobalAttr<Style>,

--- a/src/tink/domspec/Attributes.hx
+++ b/src/tink/domspec/Attributes.hx
@@ -16,7 +16,7 @@ typedef GlobalAttr<Style> = {
   @:optional var draggable(default, never):Bool;
   @:optional var spellcheck(default, never):Bool;
   @:optional var style(default, never):Style;
-  @:optional var role(def, never):String;
+  @:optional var role(default, never):String;
 }
 
 typedef DetailsAttr = {>GlobalAttr<Style>,


### PR DESCRIPTION
The **role attribute** is used by the bootstrap css framework, but more importantly it's
a standard attribute. 

Below is a verbatim of some understandable explanation quoted from http://bucarotechelp.com/design/html/87091102.asp (also https://www.w3.org/TR/role-attribute/ )

> Seeing impaired individuals may use a screen reader application to
> convert a webpage's text to sound. However AJAX applications can update
> a webpage without the user realizing the content has changed and needs
> to be re-processed by the screen reader application. The role attribute
> can be used to inform the accessibility application that the webpage
> content has changed, and the nature of the change. They role attribute
> adds semantic value (meaning) to html elements.

The role attribute is part of the Accessible Rich Internet Applications
(ARIA) specification. Shown below are some common values:

* alert:: 	        A message with important information has appeared or changed.
* article:: 	A section of webpage content has changed.
* banner:: 	        An area that contains site related rather than page specific content has changed.
* contentinfo:: 	An area that contains information about the document has changed.
* heading:: 	A heading for a section of the page has changed.
* img:: 	        An image has appeared or changed.
* navigation:: 	A group of navigation elements like a menu bar has changed.
* menuitem:: 	An option in a menu or menubar has changed.

A complete list of possible values and their meaning is in the specification at
http://www.w3.org/TR/wai-aria/roles#role_definitions