### PR TITLE
add 3 highly used aria attributes

### DIFF
--- a/src/tink/domspec/Attributes.hx
+++ b/src/tink/domspec/Attributes.hx
@@ -16,7 +16,10 @@ typedef GlobalAttr<Style> = {
   @:optional var draggable(default, never):Bool;
   @:optional var spellcheck(default, never):Bool;
   @:optional var style(default, never):Style;
-  @:optional var role(def, never):String;
+  @:optional var role(default, never):String;
+  @:html('aria-hidden')     @:optional var ariaHidden(default, never):Bool;
+  @:html('aria-label')      @:optional var ariaLabel(default, never):String;
+  @:html('aria-labelledby') @:optional var ariaLabelledBy(default, never):String;
 }
 
 typedef DetailsAttr = {>GlobalAttr<Style>,


### PR DESCRIPTION
`aria-hidden, aria-label and aria-labelledBy` are 3 of the most used aria attributes.

If more are required, @kLabz has proposed a very thorough class here
where all the types and attribute names can be found:
https://github.com/kLabz/haxe-react/blob/next/src/lib/react/jsx/AriaAttributes.hx