### PR TITLE
Add ClassName#when

### DIFF
--- a/src/tink/domspec/ClassName.hx
+++ b/src/tink/domspec/ClassName.hx
@@ -11,6 +11,9 @@ abstract ClassName(String) to String {
       case [null, v] | [v, null]: v;
       case [a, b]: '$a $b';
     });
+    
+  public function when(cond:Bool):ClassName
+    return new ClassName(if(cond) this else '');
 
   @:from static function ofMap(parts:Map<String, Bool>)
     return new ClassName(ofArray([for (c in parts.keys()) if (parts[c]) ofString(c)]));


### PR DESCRIPTION
This is quick hand to enable/disable a dynamic class name, where the map solution doesn't apply because it requires static class name.

e.g.:

```haxe
baseClassName.add(optionalClassName.when(cond));
```