### PR TITLE
allow svg tag `<use>`

### DIFF
--- a/src/tink/domspec/Attributes.hx
+++ b/src/tink/domspec/Attributes.hx
@@ -388,3 +388,8 @@ typedef EllipseAttr = {
   > GlobalAttr<SvgStyle>,
   > tink.svgspec.Attributes.EllipseAttr,
 }
+
+typedef UseAttr = {
+  > GlobalAttr<SvgStyle>,
+  > tink.svgspec.Attributes.UseAttr,
+}

--- a/src/tink/domspec/Attributes.hx
+++ b/src/tink/domspec/Attributes.hx
@@ -1,6 +1,7 @@
 package tink.domspec;
 
 import tink.domspec.Style;
+
 typedef GlobalAttr<Style> = {
   @:global @:html('class') @:optional var className(default, never):ClassName;
   @:global @:optional var id(default, never):String;
@@ -360,7 +361,9 @@ typedef EmbedAttr = {
 }
 
 // svg attr reference: https://github.com/dumistoklus/svg-xsd-schema/blob/master/svg.xsd
-typedef SvgAttr = {>GlobalAttr<Style>,
+typedef SvgAttr = {
+  >GlobalAttr<Style>,
+  >tink.svgspec.PresentationAttributes,
   @:optional var width(default, never):String;
   @:optional var height(default, never):String;
   @:optional var viewBox(default, never):String;// TODO: consider validating constant strings via typedef with @:fromHxx

--- a/src/tink/domspec/Tags.hx
+++ b/src/tink/domspec/Tags.hx
@@ -70,6 +70,7 @@ typedef Tags = {
     @:element(js.html.svg.CircleElement) var circle:CircleAttr;
     @:element(js.html.svg.RectElement) var rect:RectAttr;
     @:element(js.html.svg.EllipseElement) var ellipse:EllipseAttr;
+    @:element(js.html.svg.UseElement) var use:UseAttr;
   }
   var opaque:{
     var textarea:TextAreaAttr;//right?


### PR DESCRIPTION
define `<use>` tag (usable inside `<svg>` tags).
There is a join PR in `tink_svgspec` (https://github.com/haxetink/tink_svgspec/pull/1) that defines its attributes.

This enables syntax for using bootstrap svg icons (the variant using css sprites @ https://icons.getbootstrap.com/#usage) to be recognized when compiling views e.g.: 
```html
<svg width="32" height="32" fill="currentColor">
  <use href="bootstrap-icons.svg#heart-fill"/>
</svg>
``` 
