### PR TITLE
Add `AnchorTarget` enum

### DIFF
--- a/src/tink/domspec/Attributes.hx
+++ b/src/tink/domspec/Attributes.hx
@@ -214,9 +214,16 @@ typedef FormAttr = {>GlobalAttr<Style>,
 
 typedef AnchorAttr = {>GlobalAttr<Style>,
   @:optional var href(default, never):String;
-  @:optional var target(default, never):String;
+  @:optional var target(default, never):AnchorTarget;
   @:optional var type(default, never):String;
   @:optional var rel(default, never):AnchorRel;
+}
+
+@:enum abstract AnchorTarget(String) to String from String {
+  var Blank = "_blank";
+  var Parent = "_parent";
+  var Self = "_self";
+  var Top = "_top";
 }
 
 typedef OptionAttr = {>GlobalAttr<Style>,


### PR DESCRIPTION
I needed this enum on one of my projects, so it was best to integrate it with this library 😄 
A [custom name for browsing context](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target) is still allowed by the `from String` clause.