### PR TITLE
Fixes the `TimeAttr.dateTime` attribute

### DIFF
--- a/src/tink/domspec/Attributes.hx
+++ b/src/tink/domspec/Attributes.hx
@@ -31,10 +31,16 @@ typedef TimeAttr = {>GlobalAttr<Style>,
   @:optional var dateTime:DateTime;
 }
 
-abstract DateTime(String) from String {
+abstract DateTime(String) {
   inline function new(v) this = v;
+
   @:from static function ofDate(d:Date)
     return new DateTime(d.toString());
+
+  @:from static function ofFloat(f:Float) {
+    final parts = DateTools.parse(f);
+    return new DateTime('P${parts.days}DT${parts.hours}H${parts.minutes}M${parts.seconds}S');
+  }
 }
 
 typedef ObjectAttr = {>GlobalAttr<Style>,

--- a/src/tink/domspec/Attributes.hx
+++ b/src/tink/domspec/Attributes.hx
@@ -28,10 +28,10 @@ typedef FieldSetAttr = {>GlobalAttr<Style>,
 }
 
 typedef TimeAttr = {>GlobalAttr<Style>,
-  @:optional var datetime:DateTime;
+  @:optional var dateTime:DateTime;
 }
 
-abstract DateTime(String) {
+abstract DateTime(String) from String {
   inline function new(v) this = v;
   @:from static function ofDate(d:Date)
     return new DateTime(d.toString());


### PR DESCRIPTION
Fixes MVCoconut/coconut.vdom#42.

The `from String` clause added to `DateTime` is important: the `<time datetime>` attribute allows ISO8601 durations (for example: `P1DT16H56M`). Cf. https://developer.mozilla.org/en-US/docs/Web/API/HTMLTimeElement/dateTime