### PR TITLE
add ClassName.addWhen()

### DIFF
--- a/src/tink/domspec/ClassName.hx
+++ b/src/tink/domspec/ClassName.hx
@@ -22,6 +22,9 @@ abstract ClassName(String) to String {
   public function when(cond:Bool):ClassName
     return new ClassName(if(cond) this else '');
 
+  public function addWhen(that:ClassName, cond:Bool):ClassName
+    return add(that.when(cond)); 
+
   @:from static function ofMap(parts:Map<String, Bool>)
     return new ClassName(ofArray([for (c in parts.keys()) if (parts[c]) ofString(c)]));
 


### PR DESCRIPTION
Since `ClassName` is all about conveniency,

1. `className.add('item').add('show'.when(isShown))` // we already have
2. `className.add('item').addWhen('show', isShown)` // proposed here

Maps like `{['show' => isShown, 'item' => true]}` are powerful but for simple views is a lot of mental  preparation, typing nested parenthesis is also relatively a lot of work. Writing views should be as effortless as possible hence this proposal.