### PR TITLE
<select> tag in react accepts attributes 'value' and 'defaultValue'

### DIFF
--- a/src/tink/domspec/Attributes.hx
+++ b/src/tink/domspec/Attributes.hx
@@ -197,6 +197,9 @@ typedef SelectAttr = {>GlobalAttr<Style>,
   @:optional var name(default, never):String;
   @:optional var required(default, never):Bool;
   @:optional var size(default, never):Int;
+  // note: those are react-only
+  @:optional var value(default, never):String;
+  @:optional var defaultValue(default, never):String;
 }
 
 typedef FormAttr = {>GlobalAttr<Style>,


### PR DESCRIPTION
https://reactjs.org/docs/forms.html#the-select-tag

React will show a warning if using <option selected=..>