### PR TITLE
Fixes `Type not found : js.html.DialogElement`

### DIFF
--- a/src/tink/domspec/Tags.hx
+++ b/src/tink/domspec/Tags.hx
@@ -65,7 +65,7 @@ typedef Tags = {
     var dt:GlobalAttr<Style>;
     var dd:GlobalAttr<Style>;
     var details:#if haxe4 DetailsAttr #else GlobalAttr<Style>#end;
-    var dialog:DialogAttr;
+    #if (haxe_ver > 4.204) var dialog:DialogAttr; #end
     var summary:GlobalAttr<Style>;
     var sub:GlobalAttr<Style>;
     var sup:GlobalAttr<Style>;


### PR DESCRIPTION
Cf. https://github.com/haxetink/tink_domspec/pull/35#issuecomment-1049023197
I hope the `DialogElement` class will go in Haxe 4.2.5 😄 